### PR TITLE
Add BuildConfig to automate user-api build and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ docker-compose up --build
 In order to deploy the app on OpenShift just execute `./deploy_openshift.sh`. By default deployment destination is the dev cluster, but you can point it to minishift, oso, oso pro, ocp etc by setting `OPENSHIFT_ENDPOINT` env var.
 NOTE: `OPENSHIFT_TOKEN` env var with valid token must be set before executing the script.
 
+To enable CI/CD for `user-api` using an OpenShift `BuildConfig` triggered by a GitHub webhook you need to:
+
+- Set a base64 encoded secret in file `openshift/whsecret.yaml` that will be used by the webhook
+- Set `SETUP_CICD="true"` and run `./deploy_openshift.sh`
+- Configure the GitHub Webhook ([read the documentation](https://docs.openshift.org/latest/dev_guide/builds/triggering_builds.html#github-webhooks))
+
 ## Contribution
 
 This is definitely a contrived project, so it can be extended in any way you want. If you have a crazy idea (like RESTful API in Haskell that counts kittens of particular user) - just submit a PR.

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
+# TODO
+
 - Add preview URLs for every frontend command
-- Add Build commands (for user-api, todo-api, auth-api)
-- Specify the right verxion of the Eugene images where the run commands work correctly
-- Use custom images to avoid that the services are started at workspace boot
-- Automatically set usera-api nature to maven project
-- OpenShift BuildConfig (source2image) to auto build user-api
-- Deploy multi-user Che (for factories)
+- Fix "npm update check failed" for the frontend run command
+- Add mvn clean install as a post build of the Docker image of users-api
+- Make a command to build and test the users-api
+- Make a new buildconfig to build and deploy on a stage namespace when a PR is created

--- a/k8s/users-api/deployment-cicd.yaml
+++ b/k8s/users-api/deployment-cicd.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  labels:
+  app: microservice-app-example
+  name: users-api
+spec:
+  replicas: 1
+  selector:
+  app: microservice-app-example
+  deploymentconfig: users-api
+  strategy:
+  type: Rolling
+  template:
+  metadata:
+    labels:
+    app: microservice-app-example
+    deploymentconfig: users-api
+  spec:
+    containers:
+    -
+    env:
+    -
+      name: JWT_SECRET
+      value: myfancysecret
+    -
+      name: SERVER_PORT
+      value: '8083'
+    image: 172.30.1.1:5000/prod/users-api:latest
+    command: ["java"]
+    args: ["-jar", "-Dserver.port=8083", "/deployments/users-api-0.0.1-SNAPSHOT.jar"]
+    name: users-api
+    ports:
+    -
+      containerPort: 8083
+    -
+      containerPort: 8000
+    imagePullPolicy: Always
+    restartPolicy: Always
+    resources:
+      limits:
+      memory: 1512Mi
+  triggers:
+  - type: ConfigChange
+  - type: ImageChange
+    imageChangeParams:
+    automatic: true
+    containerNames:
+      - users-api
+    from:
+      kind: ImageStreamTag
+      name: users-api:latest

--- a/k8s/users-api/service-cicd.yaml
+++ b/k8s/users-api/service-cicd.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+  app: microservice-app-example
+  name: users-api
+spec:
+  ports:
+  -
+    name: web
+    port: 8083
+    protocol: TCP
+  -
+    port: 8000
+    name: debug
+    protocol: TCP
+  selector:
+  deploymentconfig: users-api

--- a/openshift/all.yml
+++ b/openshift/all.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: List
 items:
- - 
+ -
   apiVersion: v1
   kind: Pod
   metadata:
@@ -12,28 +12,28 @@ items:
    name: auth-api
   spec:
    containers:
-    - 
+    -
      env:
-      - 
+      -
        name: AUTH_API_PORT
        value: '8081'
-      - 
+      -
        name: JWT_SECRET
        value: myfancysecret
-      - 
+      -
        name: USERS_API_ADDRESS
        value: 'http://users-api:8083'
      image: eivantsov/auth-api
      imagePullPolicy: Always
      name: auth-api
      ports:
-      - 
+      -
        containerPort: 8081
      restartPolicy: Always
      resources:
       limits:
        memory: 512Mi
- - 
+ -
   apiVersion: v1
   kind: Service
   metadata:
@@ -42,11 +42,11 @@ items:
    name: auth-api
   spec:
    ports:
-    - 
+    -
      port: 8081
    selector:
     service: auth-api
- - 
+ -
   apiVersion: v1
   kind: Pod
   metadata:
@@ -56,28 +56,28 @@ items:
    name: frontend
   spec:
    containers:
-    - 
+    -
      env:
-      - 
+      -
        name: AUTH_API_ADDRESS
        value: 'http://auth-api:8081'
-      - 
+      -
        name: PORT
        value: '8080'
-      - 
+      -
        name: TODOS_API_ADDRESS
        value: 'http://todos-api:8082'
      image: eivantsov/frontend
      name: frontend
      ports:
-      - 
+      -
        containerPort: 8080
      imagePullPolicy: Always
      restartPolicy: Always
      resources:
       limits:
        memory: 512Mi
- - 
+ -
   apiVersion: v1
   kind: Service
   metadata:
@@ -86,12 +86,12 @@ items:
    name: frontend
   spec:
    ports:
-    - 
+    -
      port: 8080
    selector:
     service: frontend
    type: LoadBalancer
- - 
+ -
   apiVersion: v1
   kind: Pod
   metadata:
@@ -101,13 +101,13 @@ items:
    name: redis
   spec:
    containers:
-    - 
+    -
      env:
-      - 
+      -
        name: AUTH_API_ADDRESS
        value: 'http://auth-api:8081'
      ports:
-      - 
+      -
        containerPort: 6379
      image: redis
      name: redis
@@ -116,7 +116,7 @@ items:
      resources:
       limits:
        memory: 512Mi
- - 
+ -
   apiVersion: v1
   kind: Service
   metadata:
@@ -125,11 +125,11 @@ items:
    name: redis
   spec:
    ports:
-    - 
+    -
      port: 6379
    selector:
     service: redis
- - 
+ -
   apiVersion: v1
   kind: Pod
   metadata:
@@ -139,31 +139,31 @@ items:
    name: todos-api
   spec:
    containers:
-    - 
+    -
      env:
-      - 
+      -
        name: JWT_SECRET
        value: myfancysecret
-      - 
+      -
        name: TODO_API_PORT
        value: '8082'
-      - 
+      -
        name: REDIS_HOST
        value: redis
-      - 
+      -
        name: REDIS_PORT
        value: '6379'
-     image: ibuziuk/todos-api
+     image: eivantsov/todos-api
      name: todos-api
      ports:
-      - 
+      -
        containerPort: 8082
      imagePullPolicy: Always
      restartPolicy: Always
      resources:
       limits:
        memory: 512Mi
- - 
+ -
   apiVersion: v1
   kind: Service
   metadata:
@@ -172,41 +172,64 @@ items:
    name: todos-api
   spec:
    ports:
-    - 
+    -
      port: 8082
    selector:
     service: todos-api
- - 
+ -
   apiVersion: v1
-  kind: Pod
+  kind: DeploymentConfig
   metadata:
    labels:
     app: microservice-app-example
-    service: users-api
    name: users-api
   spec:
-   containers:
-    - 
-     env:
-      - 
+   replicas: 1
+   selector:
+    app: microservice-app-example
+    deploymentconfig: users-api
+   strategy:
+    type: Rolling
+   template:
+    metadata:
+     labels:
+      app: microservice-app-example
+      deploymentconfig: users-api
+    spec:
+     containers:
+     -
+      env:
+      -
        name: JWT_SECRET
        value: myfancysecret
-      - 
+      -
        name: SERVER_PORT
        value: '8083'
-     image: ibuziuk/user-api
-     name: users-api
-     ports:
-      - 
+      image: 172.30.1.1:5000/prod/users-api:latest
+      command: ["java"]
+      args: ["-jar", "-Dserver.port=8083", "/deployments/users-api-0.0.1-SNAPSHOT.jar"]
+      name: users-api
+      ports:
+      -
        containerPort: 8083
-      - 
+      -
        containerPort: 8000
-     imagePullPolicy: Always
-     restartPolicy: Always
-     resources:
-      limits:
+      imagePullPolicy: Always
+      restartPolicy: Always
+      resources:
+       limits:
        memory: 1512Mi
- - 
+   triggers:
+   - type: ConfigChange
+   - type: ImageChange
+     imageChangeParams:
+      automatic: true
+      containerNames:
+       - users-api
+      from:
+       kind: ImageStreamTag
+       name: users-api:latest
+ -
   apiVersion: v1
   kind: Service
   metadata:
@@ -215,13 +238,22 @@ items:
    name: users-api
   spec:
    ports:
-    - 
+    -
      name: web
      port: 8083
      protocol: TCP
-    - 
+    -
      port: 8000
      name: debug
      protocol: TCP
    selector:
-    service: users-api
+    deploymentconfig: users-api
+ -
+  apiVersion: v1
+  kind: Route
+  metadata:
+    name: frontend
+  spec:
+    to:
+      kind: Service
+      name: frontend

--- a/openshift/bc.yml
+++ b/openshift/bc.yml
@@ -1,0 +1,29 @@
+kind: "BuildConfig"
+apiVersion: "v1"
+metadata:
+  name: "users-api-build"
+spec:
+  runPolicy: "Serial"
+  triggers:
+    -
+      type: "ImageChange"
+    -
+      type: "GitHub"
+      github:
+        secretReference:
+          name: "github-webhook-secret"
+  source:
+    git:
+      uri: "https://github.com/ibuziuk/microservice-app-example"
+      ref: "master"
+    contextDir: "users-api"
+  strategy:
+    sourceStrategy:
+      from:
+        kind: "ImageStreamTag"
+        name: "redhat-openjdk18-openshift:latest"
+      incremental: true
+  output: 
+    to:
+      kind: "ImageStreamTag"
+      name: "users-api:latest"

--- a/openshift/is.yml
+++ b/openshift/is.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: users-api
+spec:
+  dockerImageRepository: ""

--- a/openshift/openjdk-s2i-imagestream.yml
+++ b/openshift/openjdk-s2i-imagestream.yml
@@ -1,0 +1,17 @@
+---
+kind: ImageStream
+apiVersion: v1
+metadata:
+  name: redhat-openjdk18-openshift
+spec:
+  dockerImageRepository: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+  tags:
+  - name: '1.0'
+    annotations:
+      description: OpenJDK S2I images.
+      iconClass: icon-jboss
+      tags: builder,java,xpaas
+      supports: java:8,xpaas:1.0
+      sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
+      sampleContextDir: undertow-servlet
+      version: '1.0'

--- a/openshift/whsecret.yml
+++ b/openshift/whsecret.yml
@@ -1,0 +1,6 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: github-webhook-secret
+data:
+  WebHookSecretKey: < change me >


### PR DESCRIPTION
Added an OpenShift BuildConfig to build `user-api` (as well as the required `ImageStream`, `Secret` and S2I openjdk base image).